### PR TITLE
Standardize config parsing

### DIFF
--- a/.devcontainer/docker-compose.vscode.yml
+++ b/.devcontainer/docker-compose.vscode.yml
@@ -8,15 +8,12 @@ services:
             # Required for the `diesel` CLI to work.
             DATABASE_URL: postgres://postgres:password@postgres/postgres
 
-            # Required for Rocket to connect to the database.
-            ROCKET_DATABASES: "{ postgres = { url = \"postgres://postgres:password@postgres/postgres\" } }"
-
-            ROCKET_REDIS_URL: redis://redis
+            REDIS_URL: redis://redis
 
             # A stable secret key so cookie sessions stay valid across restarts.
             # Generated with:
             #   $ openssl rand -base64 32
-            ROCKET_SECRET_KEY: jAxXeR+lG38ZA5ONOVci4ICc2VsuwbnHF4piuMYu8n8=
+            SECRET_KEY: jAxXeR+lG38ZA5ONOVci4ICc2VsuwbnHF4piuMYu8n8=
         volumes:
             # Mounts the project folder to '/workspace'. While this file is in .devcontainer,
             # mounts are relative to the first file in the list, which is a level up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,15 +67,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -298,17 +289,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
 dependencies = [
- "ansi_term 0.11.0",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -808,12 +814,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1230,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,9 +1431,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -2051,33 +2063,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2127,13 +2115,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -2357,7 +2351,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -2484,18 +2478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,12 +2520,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2710,6 +2686,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "chrono",
+ "clap",
  "diesel",
  "diesel_migrations",
  "password-hash",
@@ -2721,7 +2698,6 @@ dependencies = [
  "sendgrid",
  "serde",
  "serde_json",
- "structopt",
  "tera",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 argon2 = { version = "0.2.2", features = ["std"] }
 async-trait = "0.1.52"
 chrono = { version = "0.4.19", features = ["serde"] }
+clap = { version = "3.0", features = ["derive", "env"]}
 diesel = { version = "1.4.7", features = ["chrono", "postgres", "uuidv07"] }
 diesel_migrations = { version = "1.4.0", features = ["postgres"] }
 password-hash = "0.2.2"
@@ -23,7 +24,6 @@ redis = "0.21.3"
 rocket = { version = "0.5.0-rc.1", features = ["json", "secrets", "uuid"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3.22"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/README.md
+++ b/README.md
@@ -11,12 +11,27 @@ with:
 docker compose -f ./docker-compose.base.yml -f ./docker-compose.standalone.yml up
 ```
 
-## Environment Variables
+## Configuration
 
-**`ROCKET_REDIS_URL`:** Connection string used to connect to Redis. Redis is
+For a full list of configuration options, see the `help` command of the
+application binary.
+
+```bash
+zeroed-books-api help
+```
+
+### Environment Variables
+
+**`DATABASE_URL`:** The connection string used to connect to the primary
+Postgres database.
+
+**`REDIS_URL`:** Connection string used to connect to Redis. Redis is
 used as the backing store for rate limiting.
 
-**`ROCKET_SENDGRID_KEY`:** An API token for Sendgrid. If this is provided,
+**`SECRET_KEY`:** A secret key used primarily to encrypt private cookies. This
+can be generated with: `openssl rand -base64 32`.
+
+**`SENDGRID_KEY`:** An API token for Sendgrid. If this is provided,
 transactional emails will be sent using Sendgrid. If this is left empty, the
 default development setting of logging emails to the console is used.
 

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,12 +1,16 @@
 use diesel::Connection;
-use std::env;
 
 embed_migrations!();
 
-pub fn run_migrations() -> Result<(), diesel_migrations::RunMigrationsError> {
-    let db_url = env::var("DATABASE_URL").expect("$DATABASE_URL is not set.");
-    let connection =
-        diesel::PgConnection::establish(&db_url).expect("Failed to establish database connection.");
+pub struct MigrationOpts {
+    pub database_url: String,
+}
 
-    embedded_migrations::run_with_output(&connection, &mut std::io::stdout())
+pub fn run_migrations(opts: MigrationOpts) -> anyhow::Result<()> {
+    let connection = diesel::PgConnection::establish(&opts.database_url)?;
+
+    Ok(embedded_migrations::run_with_output(
+        &connection,
+        &mut std::io::stdout(),
+    )?)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,25 +1,93 @@
-use structopt::StructOpt;
+use clap::{Args, Parser, Subcommand};
+
+use crate::server;
 
 mod migrate;
 
-#[derive(StructOpt)]
-pub enum Opts {
-    Migrate {},
-    Serve {},
+#[derive(Parser)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
 }
 
-pub async fn run_with_sys_args() -> Result<(), ()> {
-    let matches = Opts::from_args();
+#[derive(Subcommand)]
+enum Commands {
+    Migrate(MigrateOpts),
+    Serve(ServeOpts),
+}
 
-    match matches {
-        Opts::Migrate {} => migrate::run_migrations().map_err(|_| ()),
-        Opts::Serve {} => crate::server::rocket()
+#[derive(Args)]
+struct MigrateOpts {
+    /// Connection string for the database.
+    #[clap(long = "database-url", env = "DATABASE_URL")]
+    database_url: String,
+}
+
+impl From<&MigrateOpts> for migrate::MigrationOpts {
+    fn from(opts: &MigrateOpts) -> Self {
+        Self {
+            database_url: opts.database_url.to_owned(),
+        }
+    }
+}
+
+#[derive(Args)]
+struct ServeOpts {
+    /// The number of connections to use for the database pool.
+    #[clap(long = "database-pool-size", default_value = "16")]
+    database_pool_size: u32,
+
+    /// The number of seconds before a database connection times out.
+    #[clap(long = "database-timeout", default_value = "5")]
+    database_timeout: u8,
+
+    /// Connection string for the application database.
+    #[clap(long = "database-url", env = "DATABASE_URL")]
+    database_url: String,
+
+    /// Connection string for Redis.
+    #[clap(long = "redis-url", env = "REDIS_URL")]
+    redis_url: String,
+
+    /// Secret key for signing application data.
+    ///
+    /// If this is changed, existing session cookies will become invalid.
+    /// Generate with: openssl rand -base64 32
+    #[clap(long = "secret-key", env = "SECRET_KEY")]
+    secret_key: String,
+
+    /// API key for SendGrid.
+    ///
+    /// If provided, emails will be sent using SendGrid. If this is not set,
+    /// emails will be printed to stdout.
+    #[clap(long = "sendgrid-key", env = "SENDGRID_KEY")]
+    sendgrid_key: Option<String>,
+}
+
+impl From<&ServeOpts> for server::Options {
+    fn from(opts: &ServeOpts) -> Self {
+        Self {
+            database_pool_size: opts.database_pool_size,
+            database_timeout_seconds: opts.database_timeout,
+            database_url: opts.database_url.to_owned(),
+            redis_url: opts.redis_url.to_owned(),
+            secret_key: opts.secret_key.to_owned(),
+            sendgrid_key: opts.sendgrid_key.to_owned(),
+        }
+    }
+}
+
+pub async fn run_with_sys_args() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Migrate(opts) => Ok(migrate::run_migrations(opts.into())?),
+        Commands::Serve(opts) => Ok(server::rocket(opts.into())?
             .ignite()
             .await
             .expect("Rocket ignition failure")
             .launch()
             .await
-            .map(|_| ())
-            .map_err(|_| ()),
+            .map(|_| ())?),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use tracing::debug;
 use zeroed_books_api::cli;
 
 #[rocket::main]
-async fn main() -> Result<(), ()> {
+async fn main() -> anyhow::Result<()> {
     // Configure a default tracing subscriber using the RUST_LOG environment
     // variable.
     tracing_subscriber::fmt::init();

--- a/src/rate_limit/redis.rs
+++ b/src/rate_limit/redis.rs
@@ -16,7 +16,7 @@ impl RedisRateLimiter {
     /// # Arguments
     ///
     /// * `connection_uri` - The connection string used to connect to Redis.
-    pub fn new(connection_uri: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn new(connection_uri: &str) -> anyhow::Result<Self> {
         Ok(Self {
             client: redis::Client::open(connection_uri)?,
         })

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -8,6 +8,16 @@ table! {
 }
 
 table! {
+    account_old (id) {
+        id -> Uuid,
+        user_id -> Nullable<Uuid>,
+        name -> Text,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+table! {
     currency (code) {
         code -> Text,
         symbol -> Text,
@@ -27,10 +37,43 @@ table! {
 }
 
 table! {
+    email_old (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        address -> Varchar,
+        verified_at -> Nullable<Timestamptz>,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+table! {
     email_verification (token) {
         token -> Text,
         email_id -> Uuid,
         created_at -> Timestamptz,
+    }
+}
+
+table! {
+    email_verification_old (token) {
+        token -> Varchar,
+        email_id -> Uuid,
+        created_at -> Timestamptz,
+    }
+}
+
+table! {
+    primary_email_old (user_id, email_id) {
+        user_id -> Uuid,
+        email_id -> Uuid,
+    }
+}
+
+table! {
+    schema_migrations (version) {
+        version -> Int8,
+        dirty -> Bool,
     }
 }
 
@@ -58,6 +101,26 @@ table! {
 }
 
 table! {
+    transaction_entry_old (transaction_id, order) {
+        transaction_id -> Uuid,
+        order -> Int4,
+        account_id -> Uuid,
+        amount -> Int8,
+    }
+}
+
+table! {
+    transaction_old (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        date -> Date,
+        payee -> Text,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+table! {
     user (id) {
         id -> Uuid,
         password -> Text,
@@ -66,20 +129,46 @@ table! {
     }
 }
 
+table! {
+    user_old (id) {
+        id -> Uuid,
+        email -> Text,
+        password_hash -> Bpchar,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
 joinable!(account -> user (user_id));
+joinable!(account_old -> user_old (user_id));
 joinable!(email -> user (user_id));
+joinable!(email_old -> user_old (user_id));
 joinable!(email_verification -> email (email_id));
+joinable!(email_verification_old -> email_old (email_id));
+joinable!(primary_email_old -> email_old (email_id));
+joinable!(primary_email_old -> user_old (user_id));
 joinable!(transaction -> user (user_id));
 joinable!(transaction_entry -> account (account_id));
 joinable!(transaction_entry -> currency (currency));
 joinable!(transaction_entry -> transaction (transaction_id));
+joinable!(transaction_entry_old -> account_old (account_id));
+joinable!(transaction_entry_old -> transaction_old (transaction_id));
+joinable!(transaction_old -> user_old (user_id));
 
 allow_tables_to_appear_in_same_query!(
     account,
+    account_old,
     currency,
     email,
+    email_old,
     email_verification,
+    email_verification_old,
+    primary_email_old,
+    schema_migrations,
     transaction,
     transaction_entry,
+    transaction_entry_old,
+    transaction_old,
     user,
+    user_old,
 );


### PR DESCRIPTION
Use the CLI entrypoint to parse all arguments rather than looking them
up via the environment in various locations. In addition to improving
consistency, we also get the benefits of generated help documentation
for the CLI.

This is a breaking change because we renamed some environment variables
to avoid exposing Rocket's config structure.

Closes #20
