### PR TITLE
Password reset request endpoint

### DIFF
--- a/src/http_err.rs
+++ b/src/http_err.rs
@@ -47,6 +47,8 @@ impl From<anyhow::Error> for ApiError {
     }
 }
 
+pub type ApiResponse<T> = Result<T, ApiError>;
+
 #[derive(Serialize)]
 pub struct ErrorRep {
     pub message: String,

--- a/src/identities/commands/mod.rs
+++ b/src/identities/commands/mod.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use tera::Tera;
+
+use crate::email::clients::EmailClient;
+
+use super::domain::password_resets::PasswordReset;
+
+pub mod postgres;
+
+#[async_trait]
+pub trait PasswordResetCommands {
+    async fn create_reset_token(
+        &self,
+        password_reset: PasswordReset,
+        mailer: &dyn EmailClient,
+        tera: &Tera,
+    ) -> Result<()>;
+}

--- a/src/identities/commands/postgres.rs
+++ b/src/identities/commands/postgres.rs
@@ -1,0 +1,99 @@
+use anyhow::Result;
+use tera::{Context, Tera};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::{
+    email::clients::{EmailClient, Message},
+    identities::{
+        domain,
+        models::password_resets::{NewPasswordReset, PasswordReset as PasswordResetModel},
+    },
+    PostgresConn,
+};
+
+use super::PasswordResetCommands;
+
+pub struct PostgresCommands<'a>(pub &'a PostgresConn);
+
+#[async_trait]
+impl<'a> PasswordResetCommands for PostgresCommands<'a> {
+    async fn create_reset_token(
+        &self,
+        password_reset: domain::password_resets::PasswordReset,
+        mailer: &dyn EmailClient,
+        tera: &Tera,
+    ) -> Result<()> {
+        let target_email = password_reset.email().address().to_owned();
+        let saved_reset = self
+            .0
+            .run::<_, Result<_>>(move |conn| {
+                use crate::schema;
+                use diesel::prelude::*;
+
+                let email_owner = schema::email::table
+                    .filter(
+                        schema::email::provided_address
+                            .eq(password_reset.email().address())
+                            .and(schema::email::verified_at.is_not_null()),
+                    )
+                    .select(schema::email::user_id);
+                let owner_result = schema::user::table
+                    .filter(schema::user::id.eq_any(email_owner))
+                    .select(schema::user::id)
+                    .get_result::<Uuid>(conn)
+                    .optional()?;
+
+                match owner_result {
+                    None => Ok(None),
+                    Some(owner) => {
+                        let model = NewPasswordReset {
+                            user_id: owner,
+                            token: password_reset.token().to_owned(),
+                        };
+
+                        let saved_reset: PasswordResetModel =
+                            diesel::insert_into(schema::password_resets::table)
+                                .values(model)
+                                .get_result(conn)?;
+
+                        Ok(Some(saved_reset))
+                    }
+                }
+            })
+            .await?;
+
+        match saved_reset {
+            Some(reset) => {
+                let mut context = Context::new();
+                context.insert("token", &reset.token);
+
+                let content = tera.render("emails/reset_password_token.txt", &context)?;
+                let message = Message {
+                    to: target_email,
+                    subject: "Reset Your Password".to_owned(),
+                    text: content,
+                };
+
+                mailer.send(&message).await?;
+
+                info!(user_id = %reset.user_id, "Sent password reset token to verified email.");
+            }
+            None => {
+                let content =
+                    tera.render("emails/reset_password_no_account.txt", &Context::new())?;
+                let message = Message {
+                    to: target_email,
+                    subject: "Password Reset Attempt".to_owned(),
+                    text: content,
+                };
+
+                mailer.send(&message).await?;
+
+                info!("Sent password reset attempt notification to unverified email.");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/identities/domain/mod.rs
+++ b/src/identities/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod email;
+pub mod password_resets;
 pub mod users;

--- a/src/identities/domain/password_resets.rs
+++ b/src/identities/domain/password_resets.rs
@@ -1,0 +1,82 @@
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use semval::prelude::*;
+
+use super::email::{Email, EmailInvalidity};
+
+#[derive(Debug)]
+pub struct PasswordReset {
+    email: Email,
+    token: String,
+}
+
+const RESET_TOKEN_LENGTH: usize = 64;
+impl PasswordReset {
+    /// Create a new password reset.
+    ///
+    /// # Arguments
+    ///
+    /// * `email` - The email address of the user requesting a password reset.
+    ///
+    /// # Returns
+    ///
+    /// A new password reset for the provided email address with a randomly
+    /// generated token.
+    pub fn new(email: Email) -> Self {
+        let token: String = thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(RESET_TOKEN_LENGTH)
+            .map(char::from)
+            .collect();
+
+        Self { email, token }
+    }
+
+    pub fn email(&self) -> &Email {
+        &self.email
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+}
+
+impl Validate for PasswordReset {
+    type Invalidity = EmailInvalidity;
+
+    fn validate(&self) -> ValidationResult<Self::Invalidity> {
+        ValidationContext::new().validate(&self.email).into()
+    }
+}
+
+impl ValidatedFrom<&str> for PasswordReset {
+    fn validated_from(from: &str) -> ValidatedResult<Self> {
+        let into = Self::new(Email::unvalidated(from.to_owned()));
+
+        match into.validate() {
+            Ok(()) => Ok(into),
+            Err(context) => Err((into, context)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn validated_from_invalid_email() {
+        let (_, context) = PasswordReset::validated_from("some-invalid-email")
+            .expect_err("invalid email should not validate");
+        let errors = context.into_iter().collect::<Vec<_>>();
+
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn validated_from_valid_email() {
+        let reset =
+            PasswordReset::validated_from("test@example.com").expect("valid email should validate");
+
+        assert_eq!(RESET_TOKEN_LENGTH, reset.token().len());
+    }
+}

--- a/src/identities/http/mod.rs
+++ b/src/identities/http/mod.rs
@@ -1,1 +1,86 @@
+use std::net::IpAddr;
+
+use rocket::{serde::json::Json, Route, State};
+use semval::ValidatedFrom;
+use tera::Tera;
+use tracing::error;
+
+use crate::{
+    create_user,
+    email::clients::EmailClient,
+    http_err::{ApiResponse, InternalServerError},
+    rate_limit::{RateLimitResult, RateLimiter},
+    verify_email, PostgresConn,
+};
+
+use super::{
+    commands::{postgres::PostgresCommands, PasswordResetCommands},
+    domain::password_resets::PasswordReset,
+};
+
 pub mod reps;
+
+pub fn routes() -> Vec<Route> {
+    routes![create_password_reset_request, create_user, verify_email]
+}
+
+#[derive(Responder)]
+pub enum CreatePasswordResetResponse<'r> {
+    #[response(status = 200)]
+    Ok(Json<reps::PasswordResetRequest<'r>>),
+    #[response(status = 400)]
+    BadRequest(Json<reps::PasswordResetError>),
+}
+
+impl<'r> From<reps::PasswordResetRequest<'r>> for CreatePasswordResetResponse<'r> {
+    fn from(response: reps::PasswordResetRequest<'r>) -> Self {
+        Self::Ok(Json(response))
+    }
+}
+
+impl From<reps::PasswordResetError> for CreatePasswordResetResponse<'_> {
+    fn from(response: reps::PasswordResetError) -> Self {
+        Self::BadRequest(Json(response))
+    }
+}
+
+#[post("/password-reset-requests", data = "<reset_request>")]
+async fn create_password_reset_request<'r>(
+    client_ip: IpAddr,
+    db: PostgresConn,
+    mailer: &State<Box<dyn EmailClient>>,
+    rate_limiter: &State<Box<dyn RateLimiter>>,
+    tera: &State<Tera>,
+    reset_request: Json<reps::PasswordResetRequest<'r>>,
+) -> ApiResponse<CreatePasswordResetResponse<'r>> {
+    let rate_limit_key = format!("/identities/password-reset-requests_post_{}", client_ip);
+    match rate_limiter.is_limited(&rate_limit_key, 10) {
+        Ok(RateLimitResult::NotLimited) => (),
+        Ok(result @ RateLimitResult::LimitedUntil(_)) => return Err(result.into()),
+        Err(error) => {
+            error!(?error, "Failed to query rate limiter.");
+
+            return Err(InternalServerError::default().into());
+        }
+    };
+
+    let password_reset = match PasswordReset::validated_from(reset_request.email) {
+        Ok(reset) => reset,
+        Err((_, context)) => {
+            return Ok(reps::PasswordResetError::from(context).into());
+        }
+    };
+
+    let commands = PostgresCommands(&db);
+    match commands
+        .create_reset_token(password_reset, mailer.as_ref(), tera)
+        .await
+    {
+        Ok(()) => Ok(reset_request.0.into()),
+        Err(error) => {
+            error!(?error, "Failed to save password reset token.");
+
+            Err(InternalServerError::default().into())
+        }
+    }
+}

--- a/src/identities/http/reps.rs
+++ b/src/identities/http/reps.rs
@@ -64,3 +64,32 @@ impl From<ValidationContext<NewUserInvalidity>> for NewUserValidationError {
         response
     }
 }
+
+#[derive(Deserialize, Serialize)]
+pub struct PasswordResetRequest<'r> {
+    pub email: &'r str,
+}
+
+#[derive(Default, Serialize)]
+pub struct PasswordResetError {
+    email: Vec<String>,
+}
+
+impl From<ValidationContext<EmailInvalidity>> for PasswordResetError {
+    fn from(validation: ValidationContext<EmailInvalidity>) -> Self {
+        let mut response = PasswordResetError::default();
+
+        for invalidity in validation.into_iter() {
+            match invalidity {
+                EmailInvalidity::MissingDomain => {
+                    response.email.push("Email is missing a domain.".to_owned())
+                }
+                EmailInvalidity::MissingSeparator => response
+                    .email
+                    .push("Email is missing an '@' symbol.".to_owned()),
+            }
+        }
+
+        response
+    }
+}

--- a/src/identities/mod.rs
+++ b/src/identities/mod.rs
@@ -1,3 +1,4 @@
+mod commands;
 pub mod domain;
 pub mod http;
 pub mod models;

--- a/src/identities/models/mod.rs
+++ b/src/identities/models/mod.rs
@@ -1,1 +1,2 @@
 pub mod email;
+pub mod password_resets;

--- a/src/identities/models/password_resets.rs
+++ b/src/identities/models/password_resets.rs
@@ -1,0 +1,18 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::schema::password_resets;
+
+#[derive(Insertable)]
+#[table_name = "password_resets"]
+pub struct NewPasswordReset {
+    pub token: String,
+    pub user_id: Uuid,
+}
+
+#[derive(Queryable)]
+pub struct PasswordReset {
+    pub token: String,
+    pub user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub async fn create_user(
                     }
                     Err(e) => {
                         error!(
-                            error = e.as_ref(),
+                            error = ?e,
                             "Failed to send duplicate registration email."
                         );
 
@@ -203,7 +203,7 @@ pub async fn create_user(
     match email_client.send(&message).await {
         Ok(()) => (),
         Err(e) => {
-            error!(error = e.as_ref(), "Failed to send verification email.");
+            error!(error = ?e, "Failed to send verification email.");
 
             return Err(InternalServerError {
                 message: "Internal server error.".to_owned(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -53,6 +53,7 @@ pub fn rocket(opts: Options) -> anyhow::Result<Rocket<Build>> {
         .manage(tera)
         .mount("/", routes![create_user, verify_email])
         .mount("/authentication", crate::authentication::http::routes())
+        .mount("/identities", crate::identities::http::routes())
         .mount("/ledger", crate::ledger::http::routes()))
 }
 

--- a/templates/emails/reset_password_no_account.txt
+++ b/templates/emails/reset_password_no_account.txt
@@ -1,0 +1,11 @@
+Hello,
+
+This email address was used in a password reset attempt, but it is not
+registered to an account. If you did not perform this action, you can safely
+ignore this email.
+
+If you do not have an account already, you may register using this email
+address.
+
+Thanks,
+The Zeroed Books Team

--- a/templates/emails/reset_password_token.txt
+++ b/templates/emails/reset_password_token.txt
@@ -1,0 +1,8 @@
+Hello,
+
+Please use the following token to reset your password:
+
+{{ token }}
+
+Thanks,
+The Zeroed Books Team


### PR DESCRIPTION
This endpoint allows for requesting a password reset token. The endpoint
always succeeds to avoid leaking email information, but the content of
the sent message depends on whether or not the email address is verified
in our database.

Part of #26
