### PR TITLE
Password reset endpoint

### DIFF
--- a/src/identities/commands/mod.rs
+++ b/src/identities/commands/mod.rs
@@ -3,7 +3,7 @@ use tera::Tera;
 
 use crate::email::clients::EmailClient;
 
-use super::domain::password_resets::PasswordReset;
+use super::domain::password_resets::NewPasswordReset;
 
 pub mod postgres;
 
@@ -11,7 +11,7 @@ pub mod postgres;
 pub trait PasswordResetCommands {
     async fn create_reset_token(
         &self,
-        password_reset: PasswordReset,
+        password_reset: NewPasswordReset,
         mailer: &dyn EmailClient,
         tera: &Tera,
     ) -> Result<()>;

--- a/src/identities/commands/mod.rs
+++ b/src/identities/commands/mod.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use tera::Tera;
 
-use crate::email::clients::EmailClient;
+use crate::{email::clients::EmailClient, passwords::Password};
 
-use super::domain::password_resets::NewPasswordReset;
+use super::domain::password_resets::{NewPasswordReset, PasswordResetToken};
 
 pub mod postgres;
 
@@ -14,5 +14,14 @@ pub trait PasswordResetCommands {
         password_reset: NewPasswordReset,
         mailer: &dyn EmailClient,
         tera: &Tera,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+pub trait UserCommands {
+    async fn reset_user_password(
+        &self,
+        token: PasswordResetToken,
+        password: Password,
     ) -> Result<()>;
 }

--- a/src/identities/commands/postgres.rs
+++ b/src/identities/commands/postgres.rs
@@ -20,7 +20,7 @@ pub struct PostgresCommands<'a>(pub &'a PostgresConn);
 impl<'a> PasswordResetCommands for PostgresCommands<'a> {
     async fn create_reset_token(
         &self,
-        password_reset: domain::password_resets::PasswordReset,
+        password_reset: domain::password_resets::NewPasswordReset,
         mailer: &dyn EmailClient,
         tera: &Tera,
     ) -> Result<()> {

--- a/src/identities/domain/password_resets.rs
+++ b/src/identities/domain/password_resets.rs
@@ -4,13 +4,13 @@ use semval::prelude::*;
 use super::email::{Email, EmailInvalidity};
 
 #[derive(Debug)]
-pub struct PasswordReset {
+pub struct NewPasswordReset {
     email: Email,
     token: String,
 }
 
 const RESET_TOKEN_LENGTH: usize = 64;
-impl PasswordReset {
+impl NewPasswordReset {
     /// Create a new password reset.
     ///
     /// # Arguments
@@ -40,7 +40,7 @@ impl PasswordReset {
     }
 }
 
-impl Validate for PasswordReset {
+impl Validate for NewPasswordReset {
     type Invalidity = EmailInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
@@ -48,7 +48,7 @@ impl Validate for PasswordReset {
     }
 }
 
-impl ValidatedFrom<&str> for PasswordReset {
+impl ValidatedFrom<&str> for NewPasswordReset {
     fn validated_from(from: &str) -> ValidatedResult<Self> {
         let into = Self::new(Email::unvalidated(from.to_owned()));
 
@@ -65,7 +65,7 @@ mod test {
 
     #[test]
     fn validated_from_invalid_email() {
-        let (_, context) = PasswordReset::validated_from("some-invalid-email")
+        let (_, context) = NewPasswordReset::validated_from("some-invalid-email")
             .expect_err("invalid email should not validate");
         let errors = context.into_iter().collect::<Vec<_>>();
 
@@ -74,8 +74,8 @@ mod test {
 
     #[test]
     fn validated_from_valid_email() {
-        let reset =
-            PasswordReset::validated_from("test@example.com").expect("valid email should validate");
+        let reset = NewPasswordReset::validated_from("test@example.com")
+            .expect("valid email should validate");
 
         assert_eq!(RESET_TOKEN_LENGTH, reset.token().len());
     }

--- a/src/identities/http/mod.rs
+++ b/src/identities/http/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{
     commands::{postgres::PostgresCommands, PasswordResetCommands},
-    domain::password_resets::PasswordReset,
+    domain::password_resets::NewPasswordReset,
 };
 
 pub mod reps;
@@ -64,7 +64,7 @@ async fn create_password_reset_request<'r>(
         }
     };
 
-    let password_reset = match PasswordReset::validated_from(reset_request.email) {
+    let password_reset = match NewPasswordReset::validated_from(reset_request.email) {
         Ok(reset) => reset,
         Err((_, context)) => {
             return Ok(reps::PasswordResetError::from(context).into());

--- a/src/identities/http/mod.rs
+++ b/src/identities/http/mod.rs
@@ -9,19 +9,110 @@ use crate::{
     create_user,
     email::clients::EmailClient,
     http_err::{ApiResponse, InternalServerError},
+    identities::queries::{postgres::PostgresQueries, PasswordResetQueries},
+    passwords::Password,
     rate_limit::{RateLimitResult, RateLimiter},
     verify_email, PostgresConn,
 };
 
 use super::{
-    commands::{postgres::PostgresCommands, PasswordResetCommands},
-    domain::password_resets::NewPasswordReset,
+    commands::{postgres::PostgresCommands, PasswordResetCommands, UserCommands},
+    domain::password_resets::{NewPasswordReset, PasswordResetToken},
+    queries,
 };
 
 pub mod reps;
 
 pub fn routes() -> Vec<Route> {
-    routes![create_password_reset_request, create_user, verify_email]
+    routes![
+        create_password_reset,
+        create_password_reset_request,
+        create_user,
+        verify_email
+    ]
+}
+
+#[derive(Responder)]
+pub enum ResetPasswordResponse {
+    #[response(status = 200)]
+    Ok(()),
+    #[response(status = 400)]
+    BadRequest(Json<reps::PasswordResetError>),
+}
+
+impl From<()> for ResetPasswordResponse {
+    fn from(_: ()) -> Self {
+        Self::Ok(())
+    }
+}
+
+impl From<reps::PasswordResetError> for ResetPasswordResponse {
+    fn from(response: reps::PasswordResetError) -> Self {
+        Self::BadRequest(Json(response))
+    }
+}
+
+#[post("/password-resets", data = "<reset_data>")]
+async fn create_password_reset<'r>(
+    client_ip: IpAddr,
+    db: PostgresConn,
+    rate_limiter: &State<Box<dyn RateLimiter>>,
+    reset_data: Json<reps::PasswordReset<'r>>,
+) -> ApiResponse<ResetPasswordResponse> {
+    let rate_limit_key = format!("/identities/password-resets_post_{}", client_ip);
+    match rate_limiter.is_limited(&rate_limit_key, 10) {
+        Ok(RateLimitResult::NotLimited) => (),
+        Ok(result @ RateLimitResult::LimitedUntil(_)) => return Err(result.into()),
+        Err(error) => {
+            error!(?error, "Failed to query rate limiter.");
+
+            return Err(InternalServerError::default().into());
+        }
+    };
+
+    let password = match Password::validated_from(reset_data.new_password) {
+        Ok(password) => password,
+        Err((_, context)) => {
+            return Ok(reps::PasswordResetError::from(context).into());
+        }
+    };
+
+    let queries = PostgresQueries(&db);
+
+    let password_reset_data = match queries
+        .get_password_reset(reset_data.token.to_owned())
+        .await
+    {
+        Ok(data) => data,
+        Err(error @ queries::PasswordResetError::NotFound) => {
+            return Ok(reps::PasswordResetError::from(error).into())
+        }
+        Err(error) => {
+            error!(?error, "Failed to query for password reset.");
+
+            return Err(InternalServerError::default().into());
+        }
+    };
+
+    let validated_token = match PasswordResetToken::validated_from(password_reset_data) {
+        Ok(token) => token,
+        Err((_, context)) => {
+            return Ok(reps::PasswordResetError::from(context).into());
+        }
+    };
+
+    let commands = PostgresCommands(&db);
+    match commands
+        .reset_user_password(validated_token, password)
+        .await
+    {
+        Ok(()) => Ok(().into()),
+        Err(error) => {
+            error!(?error, "Failed to change user's password.");
+
+            Err(InternalServerError::default().into())
+        }
+    }
 }
 
 #[derive(Responder)]
@@ -29,7 +120,7 @@ pub enum CreatePasswordResetResponse<'r> {
     #[response(status = 200)]
     Ok(Json<reps::PasswordResetRequest<'r>>),
     #[response(status = 400)]
-    BadRequest(Json<reps::PasswordResetError>),
+    BadRequest(Json<reps::PasswordResetRequestError>),
 }
 
 impl<'r> From<reps::PasswordResetRequest<'r>> for CreatePasswordResetResponse<'r> {
@@ -38,8 +129,8 @@ impl<'r> From<reps::PasswordResetRequest<'r>> for CreatePasswordResetResponse<'r
     }
 }
 
-impl From<reps::PasswordResetError> for CreatePasswordResetResponse<'_> {
-    fn from(response: reps::PasswordResetError) -> Self {
+impl From<reps::PasswordResetRequestError> for CreatePasswordResetResponse<'_> {
+    fn from(response: reps::PasswordResetRequestError) -> Self {
         Self::BadRequest(Json(response))
     }
 }
@@ -67,7 +158,7 @@ async fn create_password_reset_request<'r>(
     let password_reset = match NewPasswordReset::validated_from(reset_request.email) {
         Ok(reset) => reset,
         Err((_, context)) => {
-            return Ok(reps::PasswordResetError::from(context).into());
+            return Ok(reps::PasswordResetRequestError::from(context).into());
         }
     };
 

--- a/src/identities/mod.rs
+++ b/src/identities/mod.rs
@@ -2,3 +2,4 @@ mod commands;
 pub mod domain;
 pub mod http;
 pub mod models;
+mod queries;

--- a/src/identities/models/password_resets.rs
+++ b/src/identities/models/password_resets.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use crate::schema::password_resets;
+use crate::{identities::domain, schema::password_resets};
 
 #[derive(Insertable)]
 #[table_name = "password_resets"]
@@ -15,4 +15,14 @@ pub struct PasswordReset {
     pub token: String,
     pub user_id: Uuid,
     pub created_at: DateTime<Utc>,
+}
+
+impl From<PasswordReset> for domain::password_resets::PasswordResetTokenData {
+    fn from(reset: PasswordReset) -> Self {
+        Self {
+            user_id: reset.user_id,
+            token: reset.token,
+            created_at: reset.created_at,
+        }
+    }
 }

--- a/src/identities/queries/mod.rs
+++ b/src/identities/queries/mod.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+use super::domain::password_resets::PasswordResetTokenData;
+
+pub mod postgres;
+
+#[derive(Debug)]
+pub enum PasswordResetError {
+    NotFound,
+    Unknown(anyhow::Error),
+}
+
+#[async_trait]
+pub trait PasswordResetQueries {
+    async fn get_password_reset(
+        &self,
+        token: String,
+    ) -> Result<PasswordResetTokenData, PasswordResetError>;
+}

--- a/src/identities/queries/postgres.rs
+++ b/src/identities/queries/postgres.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+
+use crate::{
+    identities::{
+        domain::password_resets::PasswordResetTokenData, models::password_resets::PasswordReset,
+    },
+    PostgresConn,
+};
+
+use super::{PasswordResetError, PasswordResetQueries};
+
+pub struct PostgresQueries<'a>(pub &'a PostgresConn);
+
+impl From<diesel::result::Error> for PasswordResetError {
+    fn from(error: diesel::result::Error) -> Self {
+        Self::Unknown(error.into())
+    }
+}
+
+#[async_trait]
+impl<'a> PasswordResetQueries for PostgresQueries<'a> {
+    async fn get_password_reset(
+        &self,
+        provided_token: String,
+    ) -> Result<PasswordResetTokenData, PasswordResetError> {
+        let reset = self
+            .0
+            .run::<_, Result<_, PasswordResetError>>(move |conn| {
+                use crate::schema::password_resets::dsl::*;
+                use diesel::prelude::*;
+
+                Ok(password_resets
+                    .filter(token.eq(provided_token))
+                    .get_result::<PasswordReset>(conn)
+                    .optional()?)
+            })
+            .await?;
+
+        match reset {
+            Some(reset) => Ok(reset.into()),
+            None => Err(PasswordResetError::NotFound),
+        }
+    }
+}


### PR DESCRIPTION
The endpoint allows for resetting a password using a token received at a
verified email address.

Closes #26
