### PR TITLE
Filter transaction list by account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-trait",
+ "base64",
  "chrono",
  "clap",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 argon2 = { version = "0.3.3", features = ["std"] }
 async-trait = "0.1.52"
+base64 = "0.13.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "3.0", features = ["derive", "env"]}
 diesel = { version = "1.4.8", features = ["chrono", "postgres", "uuidv07"] }

--- a/src/ledger/domain/transactions.rs
+++ b/src/ledger/domain/transactions.rs
@@ -161,6 +161,14 @@ impl TransactionEntry {
     }
 }
 
+/// A cursor into a collection of transactions. Since transactions are always
+/// ordered by descending date and creation time, we can use those fields to
+/// mark arbitrary locations in the collection.
+pub struct TransactionCursor {
+    pub after_date: NaiveDate,
+    pub after_created_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod test {
 

--- a/src/ledger/queries/mod.rs
+++ b/src/ledger/queries/mod.rs
@@ -2,6 +2,7 @@ pub mod postgres;
 
 use std::collections::HashMap;
 
+use anyhow::Result;
 use uuid::Uuid;
 
 use super::domain;
@@ -37,8 +38,23 @@ pub trait TransactionQueries {
         transaction_id: Uuid,
     ) -> anyhow::Result<Option<domain::transactions::Transaction>>;
 
+    #[deprecated(note = "Use list_transactions instead.")]
     async fn latest_transactions(
         &self,
         user_id: Uuid,
     ) -> anyhow::Result<Vec<domain::transactions::Transaction>>;
+
+    async fn list_transactions(&self, query: TransactionQuery) -> Result<TransactionCollection>;
+}
+
+#[derive(Default)]
+pub struct TransactionQuery {
+    pub user_id: Uuid,
+    pub after: Option<domain::transactions::TransactionCursor>,
+    pub account: Option<String>,
+}
+
+pub struct TransactionCollection {
+    pub next: Option<domain::transactions::TransactionCursor>,
+    pub items: Vec<domain::transactions::Transaction>,
 }

--- a/src/ledger/queries/mod.rs
+++ b/src/ledger/queries/mod.rs
@@ -38,12 +38,6 @@ pub trait TransactionQueries {
         transaction_id: Uuid,
     ) -> anyhow::Result<Option<domain::transactions::Transaction>>;
 
-    #[deprecated(note = "Use list_transactions instead.")]
-    async fn latest_transactions(
-        &self,
-        user_id: Uuid,
-    ) -> anyhow::Result<Vec<domain::transactions::Transaction>>;
-
     async fn list_transactions(&self, query: TransactionQuery) -> Result<TransactionCollection>;
 }
 

--- a/src/ledger/queries/postgres.rs
+++ b/src/ledger/queries/postgres.rs
@@ -1,14 +1,18 @@
 use std::{collections::HashMap, convert::TryInto};
 
+use anyhow::Result;
 use tracing::{debug, trace};
 use uuid::Uuid;
 
 use crate::{
-    ledger::{domain, models},
+    ledger::{
+        domain::{self, transactions::TransactionCursor},
+        models,
+    },
     schema, PostgresConn,
 };
 
-use super::{CurrencyQueries, TransactionQueries};
+use super::{CurrencyQueries, TransactionCollection, TransactionQueries, TransactionQuery};
 
 pub struct PostgresQueries<'a>(pub &'a PostgresConn);
 
@@ -17,7 +21,7 @@ impl<'a> CurrencyQueries for PostgresQueries<'a> {
     async fn get_currencies_by_code(
         &self,
         currency_codes: Vec<String>,
-    ) -> anyhow::Result<HashMap<String, domain::currency::Currency>> {
+    ) -> Result<HashMap<String, domain::currency::Currency>> {
         use diesel::prelude::*;
         use schema::currency::dsl::*;
 
@@ -41,13 +45,18 @@ impl<'a> CurrencyQueries for PostgresQueries<'a> {
 
 type TransactionWithEntries = (models::Transaction, Vec<models::FullTransactionEntry>);
 
+// Why is this a u8? It has to be convertable to an i64 for limiting the query
+// size, and convertable to usize for comparing to the length of a vector. This
+// is the type that fits.
+const TRANSACTION_PAGE_SIZE: u8 = 50;
+
 #[async_trait]
 impl<'a> TransactionQueries for PostgresQueries<'a> {
     async fn get_transaction(
         &self,
         user_id: Uuid,
         transaction_id: Uuid,
-    ) -> anyhow::Result<Option<domain::transactions::Transaction>> {
+    ) -> Result<Option<domain::transactions::Transaction>> {
         use diesel::prelude::*;
 
         trace!(%user_id, %transaction_id, "Querying for transaction by ID.");
@@ -96,7 +105,7 @@ impl<'a> TransactionQueries for PostgresQueries<'a> {
     async fn latest_transactions(
         &self,
         user_id: Uuid,
-    ) -> anyhow::Result<Vec<domain::transactions::Transaction>> {
+    ) -> Result<Vec<domain::transactions::Transaction>> {
         use diesel::prelude::*;
 
         let transaction_data: Vec<TransactionWithEntries> = self
@@ -126,5 +135,102 @@ impl<'a> TransactionQueries for PostgresQueries<'a> {
             .iter()
             .map(|(transaction, entries)| transaction.try_into_domain(entries))
             .collect::<anyhow::Result<Vec<domain::transactions::Transaction>>>()?)
+    }
+
+    async fn list_transactions(&self, query: TransactionQuery) -> Result<TransactionCollection> {
+        let (transaction_data, has_next_page) = self
+            .0
+            .run::<_, Result<_>>(move |conn| {
+                use diesel::prelude::*;
+                let filter = {
+                    use schema::transaction::dsl::*;
+
+                    let mut matching_transactions = transaction
+                        .filter(user_id.eq(query.user_id))
+                        .order((date.desc(), created_at.desc()))
+                        .into_boxed();
+
+                    if let Some(ref account) = query.account {
+                        use diesel::dsl::sql;
+                        use diesel::sql_types::Text;
+
+                        let account_transactions = schema::transaction_entry::table
+                            .left_join(transaction)
+                            .left_join(schema::account::table)
+                            .filter(
+                                schema::account::name.eq(account).or(schema::account::name
+                                    .like(sql("").bind::<Text, _>(account).sql(" || ':%'"))),
+                            )
+                            .distinct_on(id)
+                            .select(id);
+
+                        matching_transactions =
+                            matching_transactions.filter(id.eq_any(account_transactions));
+                    }
+
+                    if let Some(cursor) = query.after {
+                        matching_transactions = matching_transactions.filter(
+                            date.lt(cursor.after_date).or(date
+                                .eq(cursor.after_date)
+                                .and(created_at.lt(cursor.after_created_at))),
+                        );
+                    }
+
+                    matching_transactions.limit(i64::from(TRANSACTION_PAGE_SIZE) + 1)
+                };
+
+                trace!(
+                    query = %diesel::debug_query(&filter),
+                    "Listing transactions."
+                );
+
+                let mut transactions = filter.get_results::<models::Transaction>(conn)?;
+
+                // To figure out if there is a next page, we query one more
+                // element than the maximum page size. If it exists, we remove
+                // it from the page, but remember that there are more elements.
+                let has_next_page = transactions.len() == usize::from(TRANSACTION_PAGE_SIZE) + 1;
+                if has_next_page {
+                    transactions.pop();
+                }
+
+                let entries = models::TransactionEntry::belonging_to(&transactions)
+                    .inner_join(schema::account::table)
+                    .inner_join(schema::currency::table)
+                    .order(schema::transaction_entry::order)
+                    .load::<models::FullTransactionEntry>(conn)?
+                    .grouped_by(&transactions);
+
+                Ok((
+                    transactions
+                        .drain(..)
+                        .zip(entries)
+                        .collect::<Vec<TransactionWithEntries>>(),
+                    has_next_page,
+                ))
+            })
+            .await?;
+
+        let transactions = transaction_data
+            .iter()
+            .map(|(transaction, entries)| transaction.try_into_domain(entries))
+            .collect::<Result<Vec<domain::transactions::Transaction>>>()?;
+
+        let cursor = match has_next_page {
+            true => {
+                let last_transaction = &transactions[transactions.len() - 1];
+
+                Some(TransactionCursor {
+                    after_date: last_transaction.date,
+                    after_created_at: last_transaction.created_at,
+                })
+            }
+            false => None,
+        };
+
+        Ok(TransactionCollection {
+            next: cursor,
+            items: transactions,
+        })
     }
 }

--- a/src/ledger/queries/postgres.rs
+++ b/src/ledger/queries/postgres.rs
@@ -102,41 +102,6 @@ impl<'a> TransactionQueries for PostgresQueries<'a> {
         }
     }
 
-    async fn latest_transactions(
-        &self,
-        user_id: Uuid,
-    ) -> Result<Vec<domain::transactions::Transaction>> {
-        use diesel::prelude::*;
-
-        let transaction_data: Vec<TransactionWithEntries> = self
-            .0
-            .run::<_, anyhow::Result<_>>(move |conn| {
-                let mut transactions = schema::transaction::table
-                    .filter(schema::transaction::user_id.eq(user_id))
-                    .order((
-                        schema::transaction::date.desc(),
-                        schema::transaction::created_at.desc(),
-                    ))
-                    .limit(50)
-                    .load::<models::Transaction>(conn)?;
-
-                let entries = models::TransactionEntry::belonging_to(&transactions)
-                    .inner_join(schema::account::table)
-                    .inner_join(schema::currency::table)
-                    .order(schema::transaction_entry::order)
-                    .load::<models::FullTransactionEntry>(conn)?
-                    .grouped_by(&transactions);
-
-                Ok(transactions.drain(..).zip(entries).collect::<_>())
-            })
-            .await?;
-
-        Ok(transaction_data
-            .iter()
-            .map(|(transaction, entries)| transaction.try_into_domain(entries))
-            .collect::<anyhow::Result<Vec<domain::transactions::Transaction>>>()?)
-    }
-
     async fn list_transactions(&self, query: TransactionQuery) -> Result<TransactionCollection> {
         let (transaction_data, has_next_page) = self
             .0


### PR DESCRIPTION
The transaction list can now be filtered by account. It is also
paginated. Since transactions are always listed in the same order, the
pagination is implemented with a cursor pointing to the last seen item.
Providing it to the next request will only return transactions occurring
after the item the cursor refers to.
