### PR TITLE
feat: Account list endpoint.

### DIFF
--- a/src/ledger/http/mod.rs
+++ b/src/ledger/http/mod.rs
@@ -25,6 +25,7 @@ pub fn routes() -> Vec<Route> {
         create_transaction,
         delete_transaction,
         get_account_balance,
+        get_accounts,
         get_transaction,
         get_transactions,
         update_transaction,
@@ -69,6 +70,27 @@ async fn get_account_balance(
         )),
         Err(error) => {
             error!(%account, ?error, "Failed to query for account balance.");
+
+            Err(InternalServerError::default().into())
+        }
+    }
+}
+
+#[get("/accounts?<query>")]
+async fn get_accounts(
+    db: PostgresConn,
+    session: Session,
+    query: Option<String>,
+) -> ApiResponse<Json<Vec<String>>> {
+    let queries = PostgresQueries(&db);
+
+    match queries
+        .list_accounts_by_popularity(session.user_id(), query)
+        .await
+    {
+        Ok(accounts) => Ok(Json(accounts)),
+        Err(error) => {
+            error!(?error, "Failed to list accounts.");
 
             Err(InternalServerError::default().into())
         }

--- a/src/ledger/queries/mod.rs
+++ b/src/ledger/queries/mod.rs
@@ -31,6 +31,25 @@ pub trait AccountQueries {
         user_id: Uuid,
         account_name: String,
     ) -> Result<Vec<CurrencyAmount>>;
+
+    /// List accounts by popularity.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The ID of the user to list accounts for.
+    /// * `search_string` - An optional search string used to match account
+    ///   names. If given, only accounts containing the given search string will
+    ///   be matched.
+    ///
+    /// # Returns
+    ///
+    /// A list of account names ranked by the number of transaction entries
+    /// associated with them.
+    async fn list_accounts_by_popularity(
+        &self,
+        user_id: Uuid,
+        search_string: Option<String>,
+    ) -> Result<Vec<String>>;
 }
 
 #[async_trait]


### PR DESCRIPTION
The account list endpoint lists account names by popularity, where
popularity is defined by the number of transaction entries associated
with the account.

Closes #22
