### PR TITLE
ci: Use action for running clippy.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,10 @@ jobs:
       - name: Verify formatting
         run: cargo fmt --all -- --check
 
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings
 
       - name: Build
         run: cargo build --verbose


### PR DESCRIPTION
Use a prebuilt GitHub Action for running clippy that reports errors as
annotations on the code itself.
