### PR TITLE
Refactor identities service

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -227,7 +227,7 @@
     },
     "query": "\n            SELECT code, symbol, minor_units\n            FROM currency\n            WHERE code = $1\n            "
   },
-  "847971f288b8523ae7311d081bc22b09477e7d6b044e72cead44260f5229484d": {
+  "974373028857aa523c743fb183c1ac4ae8a9f0aec8b88adf78e9c7bb4b9358cc": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -237,20 +237,7 @@
         ]
       }
     },
-    "query": "\n                DELETE FROM email_verification\n                WHERE token = $1\n                "
-  },
-  "91ffbb3e8265046387cda5295aaf25a553e960eab8b8ff99328f604b5c275631": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        INSERT INTO \"user\" (id, password)\n        VALUES ($1, $2)\n        "
+    "query": "\n                    DELETE FROM email_verification\n                    WHERE token = $1\n                    "
   },
   "9df3cf96fdece6dbc1982c9b2ad50db5347493c14befa471e0a4a57c3c698c0f": {
     "describe": {
@@ -351,27 +338,6 @@
     },
     "query": "\n            UPDATE transaction\n            SET\n                date = $3,\n                payee = $4,\n                notes = $5\n            WHERE id = $1 AND user_id = $2\n            RETURNING *\n            "
   },
-  "afc3c55c42244016261b681d3ad83b50a1fdac7ff40cbd377b03c9cb2481f10e": {
-    "describe": {
-      "columns": [
-        {
-          "name": "provided_address",
-          "ordinal": 0,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Timestamptz"
-        ]
-      }
-    },
-    "query": "\n        WITH pending_verification_emails AS (\n            SELECT email_id\n            FROM email_verification\n            WHERE token = $1 AND created_at > $2\n        )\n        UPDATE email\n        SET verified_at = now()\n        WHERE id = ANY(SELECT * FROM pending_verification_emails)\n        RETURNING provided_address\n        "
-  },
   "b2e3184b9de3bf24967b42f62004a9116837c4c0d5f4774f4947a1c876462f25": {
     "describe": {
       "columns": [],
@@ -462,6 +428,19 @@
     },
     "query": "\n            DELETE FROM transaction_entry\n            WHERE transaction_id = $1\n            "
   },
+  "d6f8e7326a4579e396675d83bbf5011beaba64af45bbd5c2b8a9ff6a278dd975": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n            INSERT INTO \"user\" (id, password)\n            VALUES ($1, $2)\n            "
+  },
   "e0ec74545d6912b117c4c20ad7edf61dbf9c37ce7ff8f253009c44d1e414a12f": {
     "describe": {
       "columns": [
@@ -520,6 +499,38 @@
       }
     },
     "query": "\n            INSERT INTO transaction (user_id, \"date\", payee, notes)\n            VALUES ($1, $2, $3, $4)\n            RETURNING id, user_id, date, payee, notes, created_at, updated_at\n            "
+  },
+  "ee18022cf2e065c72935f21be7899797b93dd694f8e56460d28cf9f81354c374": {
+    "describe": {
+      "columns": [
+        {
+          "name": "provided_address",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n            WITH pending_verification_emails AS (\n                SELECT email_id\n                FROM email_verification\n                WHERE token = $1 AND created_at > (now() - INTERVAL '1 DAY')\n            )\n            UPDATE email\n            SET verified_at = now()\n            WHERE id = ANY(SELECT * FROM pending_verification_emails)\n            RETURNING provided_address\n            "
+  },
+  "f65168267e604c98861b9a16cee2411c2e0d63055d1e70d070daedf19d1b1922": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n            DELETE FROM email_verification\n            WHERE token = $1\n            "
   },
   "fe26d9547a9dcac20fe6d9508af002a7e83ad1dcad6645d63889cbae23492bd4": {
     "describe": {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,20 @@
+use std::ops::Deref;
+
+use sqlx::PgPool;
+
+#[derive(Clone)]
+pub struct PostgresConnection(PgPool);
+
+impl PostgresConnection {
+    pub fn new(pool: PgPool) -> Self {
+        Self(pool)
+    }
+}
+
+impl Deref for PostgresConnection {
+    type Target = PgPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/identities/http/reps.rs
+++ b/src/identities/http/reps.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     identities::{
         domain::{
-            self, email::EmailInvalidity, password_resets::PasswordResetTokenInvalidity,
-            users::NewUserInvalidity,
+            self,
+            email::EmailInvalidity,
+            password_resets::PasswordResetTokenInvalidity,
+            users::{NewUser, NewUserInvalidity},
         },
         queries,
     },
@@ -30,6 +32,14 @@ impl From<NewUserRequest> for domain::users::NewUserData {
 #[derive(Serialize)]
 pub struct NewUserResponse {
     pub email: String,
+}
+
+impl From<NewUser> for NewUserResponse {
+    fn from(user: NewUser) -> Self {
+        Self {
+            email: user.email().address().to_owned(),
+        }
+    }
 }
 
 #[derive(Default, Serialize)]

--- a/src/identities/mod.rs
+++ b/src/identities/mod.rs
@@ -3,3 +3,4 @@ pub mod domain;
 pub mod http;
 pub mod models;
 mod queries;
+pub mod services;

--- a/src/identities/models/email.rs
+++ b/src/identities/models/email.rs
@@ -1,4 +1,5 @@
 use sqlx::{Executor, PgPool, Postgres};
+use thiserror::Error;
 use uuid::Uuid;
 
 use crate::identities::domain::email::{Email, EmailVerification};
@@ -59,16 +60,12 @@ impl NewEmail {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum EmailPersistanceError {
-    DatabaseError(sqlx::Error),
+    #[error("database error: {0}")]
+    DatabaseError(#[from] sqlx::Error),
+    #[error("duplicate email address: {0:?}")]
     DuplicateEmail(NewEmail),
-}
-
-impl From<sqlx::Error> for EmailPersistanceError {
-    fn from(err: sqlx::Error) -> Self {
-        EmailPersistanceError::DatabaseError(err)
-    }
 }
 
 #[derive(Debug)]

--- a/src/identities/services.rs
+++ b/src/identities/services.rs
@@ -1,0 +1,208 @@
+use std::{convert::TryFrom, sync::Arc};
+
+use anyhow::Context;
+use semval::ValidatedFrom;
+use sqlx::PgPool;
+use tera::Tera;
+use tracing::{debug, error};
+
+use crate::{
+    email::clients::{EmailClient, Message},
+    models::{self, NewUserModel},
+    rate_limit::{RateLimitResult, RateLimiter},
+};
+
+use super::{
+    domain::{
+        email::EmailVerification,
+        users::{NewUser, NewUserData, NewUserInvalidity},
+    },
+    models::email::{EmailPersistanceError, NewEmail, NewEmailVerification},
+};
+
+pub type DynEmailClient = Arc<dyn EmailClient>;
+pub type DynRateLimiter = Arc<dyn RateLimiter>;
+
+/// A service object providing functionality relating to users.
+#[derive(Clone)]
+pub struct UserService {
+    db: PgPool,
+    email_client: DynEmailClient,
+    rate_limiter: DynRateLimiter,
+    templates: Tera,
+}
+
+pub enum CreateUserResult {
+    /// The new user was successfully created.
+    ///
+    /// This means that either the user did not already exist in the database
+    /// and has now been persisted, or the provided email was a duplicate and
+    /// a notice has been sent to the address.
+    Created(NewUser),
+
+    /// The provided user data is invalid.
+    InvalidUser(semval::context::Context<NewUserInvalidity>),
+
+    /// The operation is rate limited for the provided client.
+    RateLimited(RateLimitResult),
+}
+
+impl UserService {
+    /// Create a new user service.
+    ///
+    /// # Arguments
+    ///
+    /// * `db` - The database executor to use.
+    /// * `email_client` - The client used to send emails.
+    /// * `rate_limiter` - The rate limiter to use for rate limited operations.
+    /// * `templates` - The templating engine to use for composing email
+    ///   content.
+    ///
+    /// # Returns
+    ///
+    /// A new [`UserService`] instance.
+    pub fn new(
+        db: PgPool,
+        email_client: DynEmailClient,
+        rate_limiter: DynRateLimiter,
+        templates: Tera,
+    ) -> Self {
+        Self {
+            db,
+            email_client,
+            rate_limiter,
+            templates,
+        }
+    }
+
+    /// Create a new user.
+    ///
+    /// We only create a new user if the provided email does not match one that
+    /// already exists. In the case of a duplicate email, we send a notification
+    /// to that email that the account already exists. For new users, we persist
+    /// the user and email, and then send a verification email.
+    ///
+    /// In either case, we don't return any information indicating whether or
+    /// not the email already existed in order to avoid leaking information.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_identifier` - A unique identifier for the client performing
+    ///   the operation. This is used for rate limiting.
+    /// * `new_user_data` - The new user's information.
+    pub async fn create_user(
+        &self,
+        client_identifier: &str,
+        new_user_data: NewUserData,
+    ) -> anyhow::Result<CreateUserResult> {
+        let rate_limit_key = format!("/identities/users_post_{}", client_identifier);
+        match self.rate_limiter.is_limited(&rate_limit_key, 10) {
+            Ok(RateLimitResult::NotLimited) => (),
+            Ok(result @ RateLimitResult::LimitedUntil(_)) => {
+                return Ok(CreateUserResult::RateLimited(result));
+            }
+            Err(error) => {
+                error!(?error, "Failed to query rate limiter for creating user.");
+
+                return Err(error);
+            }
+        };
+
+        let new_user = match NewUser::validated_from(new_user_data) {
+            Ok(user) => user,
+            Err((_, context)) => {
+                debug!(?context, "New user data is invalid.");
+
+                return Ok(CreateUserResult::InvalidUser(context));
+            }
+        };
+
+        let user_model = models::NewUserModel::try_from(&new_user)
+            .context("Failed to convert from domain to model.")?;
+        let email_model = NewEmail::for_user(new_user.id(), new_user.email());
+
+        let persistance_result = self.persist_new_user(&user_model, &email_model).await;
+
+        if let Err(persistence_err) = persistance_result {
+            match persistence_err {
+                EmailPersistanceError::DuplicateEmail(_) => {
+                    let content = self
+                        .templates
+                        .render("emails/duplicate.txt", &tera::Context::new())?;
+
+                    let message = Message {
+                        to: new_user.email().address().to_owned(),
+                        subject: "Duplicate Registration".to_owned(),
+                        text: content,
+                    };
+
+                    self.email_client
+                        .send(&message)
+                        .await
+                        .context("Failed to send duplicate registration email.")?;
+
+                    return Ok(CreateUserResult::Created(new_user));
+                }
+                error => {
+                    error!(?error, "Failed to persist new user.");
+
+                    return Err(error.into());
+                }
+            }
+        }
+
+        let verification = EmailVerification::new();
+        let verification_model = NewEmailVerification::new(email_model.id(), &verification);
+
+        verification_model
+            .save(&self.db)
+            .await
+            .context("Failed to save email verification model.")?;
+
+        let mut verification_context = tera::Context::new();
+        verification_context.insert("token", verification.token());
+
+        let content = self
+            .templates
+            .render("emails/verify.txt", &verification_context)
+            .context("Failed to render email verification template.")?;
+
+        let message = Message {
+            to: new_user.email().address().to_owned(),
+            subject: "Please Confirm your Email".to_owned(),
+            text: content,
+        };
+
+        self.email_client
+            .send(&message)
+            .await
+            .context("Failed to send verification email.")?;
+
+        Ok(CreateUserResult::Created(new_user))
+    }
+
+    async fn persist_new_user(
+        &self,
+        user: &NewUserModel,
+        email: &NewEmail,
+    ) -> Result<(), EmailPersistanceError> {
+        let mut tx = self.db.begin().await?;
+
+        sqlx::query!(
+            r#"
+            INSERT INTO "user" (id, password)
+            VALUES ($1, $2)
+            "#,
+            user.id,
+            user.password_hash
+        )
+        .execute(&mut tx)
+        .await?;
+
+        email.save(&mut tx).await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+}

--- a/src/ledger/http/mod.rs
+++ b/src/ledger/http/mod.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::{
     authentication::domain::session::{ExtractSession, Session},
-    http_err::{ApiError, ApiResponse, ErrorRep, InternalServerError},
+    http_err::{ApiError, ApiResponse, ErrorRep},
     server::AppState,
 };
 
@@ -59,7 +59,7 @@ async fn delete_transaction(
         Err(error) => {
             error!(?error, "Failed to delete transaction.");
 
-            Err(InternalServerError::default().into())
+            Err(ApiError::InternalServerError)
         }
     }
 }
@@ -81,7 +81,7 @@ async fn get_account_balance(
         Err(error) => {
             error!(%account, ?error, "Failed to query for account balance.");
 
-            Err(InternalServerError::default().into())
+            Err(ApiError::InternalServerError)
         }
     }
 }
@@ -106,7 +106,7 @@ async fn get_accounts(
         Err(error) => {
             error!(?error, "Failed to list accounts.");
 
-            Err(InternalServerError::default().into())
+            Err(ApiError::InternalServerError)
         }
     }
 }
@@ -151,7 +151,7 @@ async fn get_transaction(
         Err(error) => {
             error!(?error, "Failed to query for transaction.");
 
-            Err(InternalServerError::default().into())
+            Err(ApiError::InternalServerError)
         }
     }
 }
@@ -187,7 +187,7 @@ async fn get_transactions(
         Err(error) => {
             error!(?error, "Failed to list transactions.");
 
-            Err(InternalServerError::default().into())
+            Err(ApiError::InternalServerError)
         }
     }
 }
@@ -231,7 +231,7 @@ async fn create_transaction(
         Err(error) => {
             error!(?error, currency_codes = ?new_transaction.used_currency_codes(), "Failed to fetch currencies used in transaction.");
 
-            return Err(InternalServerError::default().into());
+            return Err(ApiError::InternalServerError);
         }
     };
 
@@ -247,7 +247,7 @@ async fn create_transaction(
         Err(error) => {
             error!(?error, "Failed to persist transaction.");
 
-            return Err(InternalServerError::default().into());
+            return Err(ApiError::InternalServerError);
         }
     };
 
@@ -296,7 +296,7 @@ async fn update_transaction(
         Err(error) => {
             error!(?error, currency_codes = ?updated_transaction.used_currency_codes(), "Failed to fetch currencies used in transaction.");
 
-            return Err(InternalServerError::default().into());
+            return Err(ApiError::InternalServerError);
         }
     };
 
@@ -321,7 +321,7 @@ async fn update_transaction(
         Err(error) => {
             error!(?error, %transaction_id, "Failed to update transaction.");
 
-            return Err(InternalServerError::default().into());
+            return Err(ApiError::InternalServerError);
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::{error, trace};
 pub mod authentication;
 pub mod cli;
 pub mod client_ip;
+mod database;
 mod email;
 mod http_err;
 mod identities;
@@ -28,6 +29,7 @@ pub mod ledger;
 mod models;
 pub mod passwords;
 mod rate_limit;
+mod repos;
 mod server;
 
 #[derive(Serialize)]

--- a/src/rate_limit/mod.rs
+++ b/src/rate_limit/mod.rs
@@ -1,7 +1,5 @@
 mod redis;
 
-use std::error::Error;
-
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -30,11 +28,7 @@ pub trait RateLimiter: Send + Sync {
     /// requestor's rate limit state is returned. An [Err] is returned if the
     /// rate limiter encounters an error while trying to determine if the
     /// request should be rate limited.
-    fn is_limited(
-        &self,
-        key: &str,
-        max_req_per_min: u64,
-    ) -> Result<RateLimitResult, Box<dyn Error>>;
+    fn is_limited(&self, key: &str, max_req_per_min: u64) -> anyhow::Result<RateLimitResult>;
 }
 
 #[derive(Debug)]

--- a/src/rate_limit/redis.rs
+++ b/src/rate_limit/redis.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use chrono::{Duration, DurationRound, Utc};
 use redis::Commands;
 
@@ -24,11 +22,7 @@ impl RedisRateLimiter {
 }
 
 impl RateLimiter for RedisRateLimiter {
-    fn is_limited(
-        &self,
-        key: &str,
-        max_req_per_min: u64,
-    ) -> Result<RateLimitResult, Box<dyn Error>> {
+    fn is_limited(&self, key: &str, max_req_per_min: u64) -> anyhow::Result<RateLimitResult> {
         // Rate limiting is implemented using the basic algorithm suggested by
         // the Redis documentation:
         // https://redis.com/redis-best-practices/basic-rate-limiting/

--- a/src/rate_limit/redis.rs
+++ b/src/rate_limit/redis.rs
@@ -1,7 +1,7 @@
 use chrono::{Duration, DurationRound, Utc};
 use redis::Commands;
 
-use super::{RateLimitResult, RateLimiter};
+use super::RateLimiter;
 
 /// A rate limiter that uses Redis as a backing store.
 pub struct RedisRateLimiter {
@@ -22,65 +22,6 @@ impl RedisRateLimiter {
 }
 
 impl RateLimiter for RedisRateLimiter {
-    fn is_limited(&self, key: &str, max_req_per_min: u64) -> anyhow::Result<RateLimitResult> {
-        // Rate limiting is implemented using the basic algorithm suggested by
-        // the Redis documentation:
-        // https://redis.com/redis-best-practices/basic-rate-limiting/
-
-        let mut conn = self.client.get_connection()?;
-
-        // We only do per-minute rate limiting. This means we can use the
-        // current minute as our cache key because by the time it's used again,
-        // the previous value will have expired 58 minutes ago.
-        let now = Utc::now();
-        let current_minute = now.format("%M").to_string();
-
-        let cache_key = format!("{}:{}", key, current_minute);
-
-        let hits: Option<u64> = conn.get(&cache_key)?;
-        if let Some(hit_count) = hits {
-            if hit_count > max_req_per_min {
-                // Rate limit for the current minute has already been exceeded,
-                // so just report the error along with the timestamp for when
-                // the rate limit resets.
-                //
-                // Since we use a granularity of minutes for our cache key, make
-                // sure that we truncate the expiration time to the last whole
-                // minute
-                let mut limit_expiration = now + Duration::minutes(1);
-                limit_expiration = limit_expiration
-                    .duration_trunc(Duration::minutes(1))
-                    // Truncation only fails if the timestamp excedes the max
-                    // representable timestamp in nanoseconds or if the duration
-                    // exceeds the timestamp. Neither of those cases is true
-                    // here, so we can just unwrap the result.
-                    .expect("failed to truncate time");
-
-                return Ok(RateLimitResult::LimitedUntil(limit_expiration));
-            }
-        }
-
-        // The cache key either doesn't exist or is below the allowable rate
-        // limit. Increment it by one, and ensure that the key has an expiration
-        // time of one minute.
-        //
-        // Note that the "worst case" for expiration is if the key is
-        // incremented the moment before the minute rolls over, meaning it will
-        // expire the moment before the next minute rolls over. This gives us
-        // the buffer of 58 minutes stated previously.
-        redis::pipe()
-            .atomic()
-            .cmd("INCR")
-            .arg(&cache_key)
-            .ignore()
-            .cmd("EXPIRE")
-            .arg(&cache_key)
-            .arg(59)
-            .execute(&mut conn);
-
-        Ok(RateLimitResult::NotLimited)
-    }
-
     fn record_operation(
         &self,
         key: &str,

--- a/src/rate_limit/redis.rs
+++ b/src/rate_limit/redis.rs
@@ -80,4 +80,67 @@ impl RateLimiter for RedisRateLimiter {
 
         Ok(RateLimitResult::NotLimited)
     }
+
+    fn record_operation(
+        &self,
+        key: &str,
+        max_req_per_min: u64,
+    ) -> Result<(), super::RateLimitError> {
+        // Rate limiting is implemented using the basic algorithm suggested by
+        // the Redis documentation:
+        // https://redis.com/redis-best-practices/basic-rate-limiting/
+
+        let mut conn = self.client.get_connection().map_err(anyhow::Error::from)?;
+
+        // We only do per-minute rate limiting. This means we can use the
+        // current minute as our cache key because by the time it's used again,
+        // the previous value will have expired 58 minutes ago.
+        let now = Utc::now();
+        let current_minute = now.format("%M").to_string();
+
+        let cache_key = format!("{}:{}", key, current_minute);
+
+        let hits: Option<u64> = conn.get(&cache_key).map_err(anyhow::Error::from)?;
+        if let Some(hit_count) = hits {
+            if hit_count > max_req_per_min {
+                // Rate limit for the current minute has already been exceeded,
+                // so just report the error along with the timestamp for when
+                // the rate limit resets.
+                //
+                // Since we use a granularity of minutes for our cache key, make
+                // sure that we truncate the expiration time to the last whole
+                // minute
+                let mut limit_expiration = now + Duration::minutes(1);
+                limit_expiration = limit_expiration
+                    .duration_trunc(Duration::minutes(1))
+                    // Truncation only fails if the timestamp excedes the max
+                    // representable timestamp in nanoseconds or if the duration
+                    // exceeds the timestamp. Neither of those cases is true
+                    // here, so we can just unwrap the result.
+                    .expect("failed to truncate time");
+
+                return Err(super::RateLimitError::LimitedUntil(limit_expiration));
+            }
+        }
+
+        // The cache key either doesn't exist or is below the allowable rate
+        // limit. Increment it by one, and ensure that the key has an expiration
+        // time of one minute.
+        //
+        // Note that the "worst case" for expiration is if the key is
+        // incremented the moment before the minute rolls over, meaning it will
+        // expire the moment before the next minute rolls over. This gives us
+        // the buffer of 58 minutes stated previously.
+        redis::pipe()
+            .atomic()
+            .cmd("INCR")
+            .arg(&cache_key)
+            .ignore()
+            .cmd("EXPIRE")
+            .arg(&cache_key)
+            .arg(59)
+            .execute(&mut conn);
+
+        Ok(())
+    }
 }

--- a/src/repos/email.rs
+++ b/src/repos/email.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::{database::PostgresConnection, identities::models::email::NewEmailVerification};
+
+pub type DynEmailRepo = Arc<dyn EmailRepo + Send + Sync>;
+
+#[async_trait]
+pub trait EmailRepo {
+    async fn insert_verification(
+        &self,
+        email_verification: &NewEmailVerification,
+    ) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+impl EmailRepo for PostgresConnection {
+    async fn insert_verification(
+        &self,
+        email_verification: &NewEmailVerification,
+    ) -> anyhow::Result<()> {
+        email_verification.save(self).await
+    }
+}

--- a/src/repos/email.rs
+++ b/src/repos/email.rs
@@ -1,25 +1,99 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use thiserror::Error;
 
 use crate::{database::PostgresConnection, identities::models::email::NewEmailVerification};
+
+#[derive(Debug, Error)]
+pub enum EmailVerificationError {
+    #[error("invalid verification token")]
+    InvalidToken,
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
 
 pub type DynEmailRepo = Arc<dyn EmailRepo + Send + Sync>;
 
 #[async_trait]
 pub trait EmailRepo {
+    /// Delete a specific email verification.
+    async fn delete_verification_by_token(&self, token: &str) -> anyhow::Result<()>;
+
+    /// Insert a new email verification object.
     async fn insert_verification(
         &self,
         email_verification: &NewEmailVerification,
     ) -> anyhow::Result<()>;
+
+    /// Mark a specific email as verified using a verification token.
+    async fn mark_email_as_verified(&self, token: &str) -> Result<String, EmailVerificationError>;
 }
 
 #[async_trait]
 impl EmailRepo for PostgresConnection {
+    async fn delete_verification_by_token(&self, token: &str) -> anyhow::Result<()> {
+        sqlx::query!(
+            r#"
+            DELETE FROM email_verification
+            WHERE token = $1
+            "#,
+            token
+        )
+        .execute(&**self)
+        .await?;
+
+        Ok(())
+    }
+
     async fn insert_verification(
         &self,
         email_verification: &NewEmailVerification,
     ) -> anyhow::Result<()> {
         email_verification.save(self).await
+    }
+
+    async fn mark_email_as_verified(&self, token: &str) -> Result<String, EmailVerificationError> {
+        let verified_address = sqlx::query!(
+            r#"
+            WITH pending_verification_emails AS (
+                SELECT email_id
+                FROM email_verification
+                WHERE token = $1 AND created_at > (now() - INTERVAL '1 DAY')
+            )
+            UPDATE email
+            SET verified_at = now()
+            WHERE id = ANY(SELECT * FROM pending_verification_emails)
+            RETURNING provided_address
+            "#,
+            token,
+        )
+        .fetch_optional(&**self)
+        .await?
+        .map(|record| record.provided_address);
+
+        match verified_address {
+            Some(address) => {
+                sqlx::query!(
+                    r#"
+                    DELETE FROM email_verification
+                    WHERE token = $1
+                    "#,
+                    token
+                )
+                .execute(&**self)
+                .await?;
+
+                Ok(address)
+            }
+            None => Err(EmailVerificationError::InvalidToken),
+        }
+    }
+}
+
+impl From<sqlx::Error> for EmailVerificationError {
+    fn from(error: sqlx::Error) -> Self {
+        Self::Other(error.into())
     }
 }

--- a/src/repos/mod.rs
+++ b/src/repos/mod.rs
@@ -1,0 +1,5 @@
+mod email;
+mod users;
+
+pub use email::{DynEmailRepo, EmailRepo};
+pub use users::{DynUserRepo, UserPersistenceError, UserRepo};

--- a/src/repos/mod.rs
+++ b/src/repos/mod.rs
@@ -1,5 +1,5 @@
 mod email;
 mod users;
 
-pub use email::{DynEmailRepo, EmailRepo};
+pub use email::{DynEmailRepo, EmailRepo, EmailVerificationError};
 pub use users::{DynUserRepo, UserPersistenceError, UserRepo};

--- a/src/repos/users.rs
+++ b/src/repos/users.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::{
+    database::PostgresConnection,
+    identities::models::email::{EmailPersistanceError, NewEmail},
+    models::NewUserModel,
+};
+
+#[derive(Debug, Error)]
+pub enum UserPersistenceError {
+    #[error("duplicate email address: {0:?}")]
+    DuplicateEmail(NewEmail),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+pub type DynUserRepo = Arc<dyn UserRepo + Send + Sync>;
+
+#[async_trait]
+pub trait UserRepo {
+    async fn persist_new_user(
+        &self,
+        user: &NewUserModel,
+        email: &NewEmail,
+    ) -> Result<(), UserPersistenceError>;
+}
+
+#[async_trait]
+impl UserRepo for PostgresConnection {
+    async fn persist_new_user(
+        &self,
+        user: &NewUserModel,
+        email: &NewEmail,
+    ) -> Result<(), UserPersistenceError> {
+        let mut tx = self.begin().await.map_err(anyhow::Error::from)?;
+
+        sqlx::query!(
+            r#"
+            INSERT INTO "user" (id, password)
+            VALUES ($1, $2)
+            "#,
+            user.id,
+            user.password_hash
+        )
+        .execute(&mut tx)
+        .await
+        .map_err(anyhow::Error::from)?;
+
+        email.save(&mut tx).await.map_err(|error| match error {
+            EmailPersistanceError::DuplicateEmail(email) => {
+                UserPersistenceError::DuplicateEmail(email)
+            }
+            other => UserPersistenceError::Other(other.into()),
+        })?;
+
+        tx.commit().await.map_err(anyhow::Error::from)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Refactor the identities service to extract logic from the HTTP handlers into separate service and repository objects. Building the services on top of dynamic repository types makes it easier to test the service objects without depending directly on the database. The service objects allow us to remove business logic from the handlers which means we can keep the handlers as translators between our external HTTP representations and internal types.

