### PR TITLE
feat: Cummulative account balance endpoint

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -172,6 +172,46 @@
     },
     "query": "\n            SELECT * FROM currency\n            WHERE code = ANY($1)\n            ORDER BY code\n            "
   },
+  "632768d50b82f0ee5deca2129ae223e1de5566a8e7fefd9521aeb4c6205c63c8": {
+    "describe": {
+      "columns": [
+        {
+          "name": "date!",
+          "ordinal": 0,
+          "type_info": "Date"
+        },
+        {
+          "name": "code",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "minor_units",
+          "ordinal": 2,
+          "type_info": "Int2"
+        },
+        {
+          "name": "amount!",
+          "ordinal": 3,
+          "type_info": "Int8"
+        }
+      ],
+      "nullable": [
+        null,
+        false,
+        false,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n            SELECT \"date!\", code, minor_units, \"amount!\"\n            FROM (\n                SELECT\n                    DATE_TRUNC($3, t.date)::date AS \"date!\",\n                    c.code,\n                    c.minor_units,\n                    COALESCE(SUM(e.amount) OVER (PARTITION BY c.code ORDER BY t.date), 0) AS \"amount!\"\n                FROM transaction_entry e\n                    LEFT JOIN transaction t ON t.id = e.transaction_id\n                    LEFT JOIN account a ON a.id = e.account_id\n                    LEFT JOIN currency c ON c.code = e.currency\n                WHERE t.user_id = $1\n                    AND (a.name = $2 OR a.name LIKE $2 || ':%')\n                ORDER BY \"date!\"\n            ) AS sums\n            WHERE \"date!\" >= DATE_TRUNC($3, NOW() - INTERVAL '1 year')\n            GROUP BY \"date!\", code, minor_units, \"amount!\"\n            ORDER BY \"date!\"\n            "
+  },
   "6b325d011eb75e07492e6eab0d9ee3e3558cdeb14b06186cbc0dd5f2b900d9cc": {
     "describe": {
       "columns": [

--- a/src/ledger/domain/currency.rs
+++ b/src/ledger/domain/currency.rs
@@ -80,6 +80,27 @@ impl Currency {
             .map_err(|_| CurrencyParseError::InvalidNumber(raw_amount.to_owned()))
     }
 
+    pub fn format_value(&self, value: i32) -> String {
+        // Preserve the sign, but then do string manipulation on the absolute
+        // value so we don't have to worry about a negative sign.
+        let sign = if value.is_negative() { "-" } else { "" };
+        let amount_str = value.abs().to_string();
+
+        // We have to pad the value in order to ensure the string is long enough
+        // to insert the decimal point at the appropriate location.
+        let padded = format!(
+            "{:0>width$}",
+            amount_str,
+            width = usize::from(self.minor_units) + 1
+        );
+        let decimal_location = padded.len() - usize::from(self.minor_units);
+
+        let whole_part = &padded[..decimal_location];
+        let decimal_part = &padded[decimal_location..];
+
+        format!("{}{}.{}", sign, whole_part, decimal_part)
+    }
+
     pub fn code(&self) -> &str {
         &self.code
     }
@@ -119,24 +140,7 @@ impl CurrencyAmount {
     }
 
     pub fn format_value(&self) -> String {
-        // Preserve the sign, but then do string manipulation on the absolute
-        // value so we don't have to worry about a negative sign.
-        let sign = if self.value.is_negative() { "-" } else { "" };
-        let amount_str = self.value.abs().to_string();
-
-        // We have to pad the value in order to ensure the string is long enough
-        // to insert the decimal point at the appropriate location.
-        let padded = format!(
-            "{:0>width$}",
-            amount_str,
-            width = usize::from(self.currency.minor_units) + 1
-        );
-        let decimal_location = padded.len() - usize::from(self.currency.minor_units);
-
-        let whole_part = &padded[..decimal_location];
-        let decimal_part = &padded[decimal_location..];
-
-        format!("{}{}.{}", sign, whole_part, decimal_part)
+        self.currency.format_value(self.value)
     }
 }
 

--- a/src/ledger/domain/mod.rs
+++ b/src/ledger/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod currency;
+pub mod reports;
 pub mod transactions;

--- a/src/ledger/domain/reports.rs
+++ b/src/ledger/domain/reports.rs
@@ -1,0 +1,62 @@
+use chrono::NaiveDate;
+
+use super::currency::Currency;
+
+/// A collection of instant balances associated with a specific currency.
+pub struct InstantBalances {
+    currency: Currency,
+    balances: Vec<InstantBalance>,
+}
+
+/// An account balance at a certain instant in time.
+pub struct InstantBalance {
+    instant: NaiveDate,
+    amount: i32,
+}
+
+impl InstantBalances {
+    /// Create a new collection of balances.
+    ///
+    /// # Arguments
+    /// * `currency` - The currency associated with the amounts.
+    pub fn new(currency: Currency) -> Self {
+        Self {
+            currency,
+            balances: vec![],
+        }
+    }
+
+    pub fn new_with_balance(currency: Currency, instant: NaiveDate, amount: i32) -> Self {
+        Self {
+            currency,
+            balances: vec![InstantBalance { instant, amount }],
+        }
+    }
+
+    /// Add a new balance to the collection.
+    ///
+    /// # Arguments
+    /// * `instant` - The instant that the balance represents.
+    /// * `amount` - The balance at the given instant.
+    pub fn push(&mut self, instant: NaiveDate, amount: i32) {
+        self.balances.push(InstantBalance { instant, amount })
+    }
+
+    pub fn currency(&self) -> &Currency {
+        &self.currency
+    }
+
+    pub fn balances(&self) -> &[InstantBalance] {
+        &self.balances
+    }
+}
+
+impl InstantBalance {
+    pub fn instant(&self) -> NaiveDate {
+        self.instant
+    }
+
+    pub fn amount(&self) -> i32 {
+        self.amount
+    }
+}

--- a/src/ledger/queries/mod.rs
+++ b/src/ledger/queries/mod.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use chrono::NaiveDate;
 use uuid::Uuid;
 
-use super::domain::{self, currency::CurrencyAmount};
+use super::domain::{self, currency::CurrencyAmount, reports::InstantBalances};
 
 /// Queries for account information.
 #[async_trait]
@@ -74,13 +74,35 @@ pub trait AccountQueries {
     /// A list containing the names of the accounts that have been recently
     /// active.
     async fn list_active_accounts(&self, user_id: &str) -> Result<Vec<String>>;
+
+    /// Get the cummulative balance for an account.
+    ///
+    /// # Arguments
+    /// * `user_id` - The ID of the user who owns the account.
+    /// * `account` - The name of the account to report balances for.
+    /// * `interval` - The interval between balance reports.
+    ///
+    /// # Returns
+    /// A map of currency codes to instant balances. The instant balances are a
+    /// vector of balances associated with a single currency, ordered by date.
+    async fn periodic_cumulative_balance(
+        &self,
+        user_id: &str,
+        account: &str,
+        interval: ReportInterval,
+    ) -> Result<HashMap<String, InstantBalances>>;
 }
 
 pub type DynAccountQueries = Arc<dyn AccountQueries + Send + Sync>;
 
 pub struct MonthAccountBalance {
     pub month: NaiveDate,
-    pub balances: Vec<CurrencyAmount>,
+    pub balance: CurrencyAmount,
+}
+
+pub enum ReportInterval {
+    Daily,
+    Monthly,
 }
 
 #[async_trait]

--- a/src/ledger/services.rs
+++ b/src/ledger/services.rs
@@ -8,9 +8,10 @@ use crate::repos::transactions::{DynTransactionRepo, TransactionQuery};
 use super::{
     domain::{
         currency::CurrencyAmount,
+        reports::InstantBalances,
         transactions::{Transaction, TransactionCursor},
     },
-    queries::DynAccountQueries,
+    queries::{DynAccountQueries, ReportInterval},
 };
 
 #[derive(Clone)]
@@ -25,6 +26,22 @@ pub struct TransactionCollection {
 }
 
 impl LedgerService {
+    pub async fn account_periodic_balance(
+        &self,
+        user_id: &str,
+        account: &str,
+        balance_type: AccountBalanceType,
+        interval: ReportInterval,
+    ) -> Result<HashMap<String, InstantBalances>> {
+        match balance_type {
+            AccountBalanceType::Cummulative => {
+                self.account_queries
+                    .periodic_cumulative_balance(user_id, account, interval)
+                    .await
+            }
+        }
+    }
+
     pub async fn get_monthly_account_balance(
         &self,
         user_id: &str,
@@ -56,4 +73,9 @@ impl LedgerService {
             next: model_collection.next,
         })
     }
+}
+
+#[derive(Debug)]
+pub enum AccountBalanceType {
+    Cummulative,
 }


### PR DESCRIPTION
Add a new periodic balance endpoint for accounts. Right now it only returns cummulative totals for the account, but it is structured to be more extensible than the monthly account balance endpoint.

Closes #185
